### PR TITLE
Fix typo in reverse function

### DIFF
--- a/stringReverse.js
+++ b/stringReverse.js
@@ -8,8 +8,8 @@ var ans1 = reverseBySeparator(ans, " ");
 //**************** IMPORTANT FUNCTION ******************************* */
 
 
-function reverseBySeparator(string, seprator) {
-    return string.split(seprator).reverse().join(seprator);
+function reverseBySeparator(string, separator) {
+    return string.split(separator).reverse().join(separator);
 }
 
 


### PR DESCRIPTION
## Summary
- fix typo `seprator` -> `separator` in `reverseBySeparator`

## Testing
- `node stringReverse.js`


------
https://chatgpt.com/codex/tasks/task_b_685532442484832f95ce7f8bd609b919